### PR TITLE
Fix random_state typing

### DIFF
--- a/template/pipelines/inference.py
+++ b/template/pipelines/inference.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 
 @pipeline
-def inference(random_state: str, target: str):
+def inference(random_state: int, target: str):
     """
     Model inference pipeline.
 


### PR DESCRIPTION
Wrong type used in inference pipeline: observed with Pydantic v2, not impacting Pydantic v1 release, though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced stability and predictability of the inference function by updating the `random_state` parameter type from `str` to `int`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->