### PR TITLE
Fix scikit-learn vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn<1.3
+scikit-learn
 copier
 jinja2-time
 zenml[server]>=0.52.0

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,4 +1,4 @@
 zenml[server]>=0.50.0
 notebook
-scikit-learn<1.3
+scikit-learn
 pyarrow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 
 
 import os
+import sys
 import shutil
 from typing import Generator
 
@@ -97,4 +98,10 @@ def clean_zenml_client(
 
     # remove all traces, and change working directory back to base path
     os.chdir(orig_cwd)
-    shutil.rmtree(str(tmp_path))
+    if sys.platform == "win32":
+        try:
+            shutil.rmtree(str(tmp_path))
+        except:
+            pass
+    else:
+        shutil.rmtree(str(tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 
 import contextlib 
 import os
+import sys
 import shutil
 from typing import Generator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@
 #  permissions and limitations under the License.
 
 
+import contextlib 
 import os
-import sys
 import shutil
 from typing import Generator
 
@@ -99,9 +99,7 @@ def clean_zenml_client(
     # remove all traces, and change working directory back to base path
     os.chdir(orig_cwd)
     if sys.platform == "win32":
-        try:
-            shutil.rmtree(str(tmp_path))
-        except:
-            pass
+        with contextlib.suppress(Exception):  
+            shutil.rmtree(str(tmp_path))  
     else:
         shutil.rmtree(str(tmp_path))


### PR DESCRIPTION
Unpin sklearn library version to address the reported vulnerability: https://github.com/zenml-io/zenml/security/dependabot/281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `scikit-learn` version requirement to be unspecified, allowing any version above the previously specified one.

- **Tests**
  - Improved platform-specific handling of directory removal in test setup, ensuring compatibility with Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->