### PR TITLE
Starter Template: Fixing the actions/workflows after the dependency cleanup

### DIFF
--- a/.github/actions/starter_template_test/action.yml
+++ b/.github/actions/starter_template_test/action.yml
@@ -54,11 +54,6 @@ runs:
     run: |
       pip install wheel uv
 
-  - name: Install setuptools on Python 3.12
-    if: ${{ inputs.python-version == '3.12' }}
-    shell: bash
-    run: pip install setuptools
-
   - name: Install ZenML
     if: ${{ inputs.ref-zenml != '' }}
     shell: bash

--- a/.github/actions/starter_template_test/action.yml
+++ b/.github/actions/starter_template_test/action.yml
@@ -54,6 +54,11 @@ runs:
     run: |
       pip install wheel uv
 
+  - name: Install setuptools on Python 3.12
+    if: ${{ inputs.python-version == '3.12' }}
+    shell: bash
+    run: pip install setuptools
+
   - name: Install ZenML
     if: ${{ inputs.ref-zenml != '' }}
     shell: bash

--- a/.github/actions/starter_template_test/action.yml
+++ b/.github/actions/starter_template_test/action.yml
@@ -69,7 +69,7 @@ runs:
   - name: Concatenate requirements
     shell: bash
     run: |
-      zenml integration export-requirements -o ./local_checkout/integration-requirements.txt sklearn
+      zenml integration export-requirements -o ./local_checkout/integration-requirements.txt sklearn pandas
       cat ./local_checkout/requirements.txt ./local_checkout/test-requirements.txt ./local_checkout/integration-requirements.txt >> ./local_checkout/all-requirements.txt
 
   - name: Install requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         stack-name: [local]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     env:
       ZENML_DEBUG: true
       ZENML_ANALYTICS_OPT_IN: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           stack-name: ${{ matrix.stack-name }}
           python-version: ${{ matrix.python-version }}
-          ref-zenml: ${{ inputs.ref-zenml || 'develop' }}
+          ref-zenml: ${{ inputs.ref-zenml || 'feature/PRD-566-dependency-cleanup' }}
           ref-template: ${{ inputs.ref-template || github.ref }}


### PR DESCRIPTION
We are separating the pandas and numpy integrations out of the main package. As this example is using pandas, we have to install the integration separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Expanded integration requirements in the GitHub Actions workflow by including an additional package, `pandas`.
	- Updated the default branch for the `ref-zenml` input in the CI workflow to target a new feature branch related to dependency cleanup.
	- Added support for the latest Python version, `3.12`, in the CI workflow.

- **Bug Fixes**
	- Adjusted the command for exporting integration requirements to ensure broader dependency management in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->