### PR TITLE
Removing Python 3.8 from the github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         stack-name: [local]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     env:
       ZENML_DEBUG: true
       ZENML_ANALYTICS_OPT_IN: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to support only Python versions 3.9, 3.10, 3.11, and 3.12, removing Python 3.8 from the testing matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->